### PR TITLE
Update 50_TelegramBot.pm

### DIFF
--- a/50_TelegramBot.pm
+++ b/50_TelegramBot.pm
@@ -2670,7 +2670,8 @@ sub TelegramBot_ParseMsg($$$)
     
     readingsBeginUpdate($hash);
 
-    readingsBulkUpdate($hash, "prevMsgId", $hash->{READINGS}{msgId}{VAL});        
+    readingsBulkUpdate($hash, "prevMsgId", $hash->{READINGS}{msgId}{VAL});
+    readingsBulkUpdate($hash, "prevMsgDate", $hash->{READINGS}{msgDate}{VAL});
     readingsBulkUpdate($hash, "prevMsgPeer", $hash->{READINGS}{msgPeer}{VAL});        
     readingsBulkUpdate($hash, "prevMsgPeerId", $hash->{READINGS}{msgPeerId}{VAL});        
     readingsBulkUpdate($hash, "prevMsgChat", $hash->{READINGS}{msgChat}{VAL});        
@@ -2682,7 +2683,8 @@ sub TelegramBot_ParseMsg($$$)
     
     readingsBeginUpdate($hash);
 
-    readingsBulkUpdate($hash, "msgId", $mid);        
+    readingsBulkUpdate($hash, "msgId", $mid);   
+    readingsBulkUpdate($hash, "msgDate", $date);
     readingsBulkUpdate($hash, "msgPeer", TelegramBot_GetFullnameForContact( $hash, $mpeernorm ));        
     readingsBulkUpdate($hash, "msgPeerId", $mpeernorm);        
     readingsBulkUpdate($hash, "msgChat", TelegramBot_GetFullnameForContact( $hash, ((!$chatId)?$mpeernorm:$chatId) ) );        

--- a/50_TelegramBot.pm
+++ b/50_TelegramBot.pm
@@ -2670,7 +2670,7 @@ sub TelegramBot_ParseMsg($$$)
     
     readingsBeginUpdate($hash);
 
-    readingsBulkUpdate($hash, "prevMsgId", $hash->{READINGS}{msgId}{VAL});
+    readingsBulkUpdate($hash, "prevMsgId", $hash->{READINGS}{msgId}{VAL});        
     readingsBulkUpdate($hash, "prevMsgDate", $hash->{READINGS}{msgDate}{VAL});
     readingsBulkUpdate($hash, "prevMsgPeer", $hash->{READINGS}{msgPeer}{VAL});        
     readingsBulkUpdate($hash, "prevMsgPeerId", $hash->{READINGS}{msgPeerId}{VAL});        
@@ -2683,7 +2683,7 @@ sub TelegramBot_ParseMsg($$$)
     
     readingsBeginUpdate($hash);
 
-    readingsBulkUpdate($hash, "msgId", $mid);   
+    readingsBulkUpdate($hash, "msgId", $mid);        
     readingsBulkUpdate($hash, "msgDate", $date);
     readingsBulkUpdate($hash, "msgPeer", TelegramBot_GetFullnameForContact( $hash, $mpeernorm ));        
     readingsBulkUpdate($hash, "msgPeerId", $mpeernorm);        


### PR DESCRIPTION
I added readings for the client's message time. This is useful for identifying old or delayed messages due to connection problems or other errors.
For example:
FHEM commands that execute critical routines like disarming the alarm system or unlocking a door can be ignored if the message was sent too long ago.